### PR TITLE
select job based on name of job

### DIFF
--- a/telegram/ext/jobqueue.py
+++ b/telegram/ext/jobqueue.py
@@ -348,6 +348,11 @@ class JobQueue(object):
 
         return tuple(job[1] for job in self.queue.queue if job)
 
+    def select_job(self, name):
+        """Returns a tuple of all jobs that are currently in the ``JobQueue`` and have the given name."""
+
+        return tuple(job[1] for job in self.queue.queue if job and job[1].name==name)
+
 
 class Job(object):
     """This class encapsulates a Job.


### PR DESCRIPTION
By selecting jobs based on their names, users can manage jobs in job_queue.
This new function return a tuple of jobs with the same name given as parameter.